### PR TITLE
Fix crash on delete all location

### DIFF
--- a/BackgroundGeolocation/MAURSQLiteLocationDAO.m
+++ b/BackgroundGeolocation/MAURSQLiteLocationDAO.m
@@ -360,7 +360,7 @@
     NSString *sql = @"UPDATE " @LC_TABLE_NAME @" SET " @LC_COLUMN_NAME_STATUS @" = ?";
 
     [queue inDatabase:^(FMDatabase *database) {
-        if ([database executeUpdate:sql], [NSString stringWithFormat:@"%ld", MAURLocationDeleted]) {
+        if ([database executeUpdate:sql, [NSString stringWithFormat:@"%ld", MAURLocationDeleted]]) {
             success = YES;
         } else {
             int errorCode = [database lastErrorCode];


### PR DESCRIPTION
There was a typo passing the arguments to the execute query call. The bracket was closed too soon