### PR TITLE
Allow transforming or rejecting coordinates with a special transform

### DIFF
--- a/BackgroundGeolocation/MAURBackgroundGeolocationFacade.h
+++ b/BackgroundGeolocation/MAURBackgroundGeolocationFacade.h
@@ -43,6 +43,17 @@
 - (void) forceSync;
 - (void) onAppTerminate;
 
+
+/**
+ * Sets a transform for each coordinate about to be committed (sent or saved for later sync).
+ * You can use this for modifying the coordinates in any way.
+ *
+ * If the transform returns <code>nil</code>, it will prevent the location from being committed.
+ * @param transform - the transform block
+ */
++ (void) setLocationTransform:(MAURLocationTransform _Nullable)transform;
++ (MAURLocationTransform _Nullable) locationTransform;
+
 @end
 
 #endif /* MAURBackgroundGeolocationFacade_h */

--- a/BackgroundGeolocation/MAURBackgroundGeolocationFacade.m
+++ b/BackgroundGeolocation/MAURBackgroundGeolocationFacade.m
@@ -26,6 +26,7 @@
 #import "MAURDistanceFilterLocationProvider.h"
 #import "MAURRawLocationProvider.h"
 #import "MAURUncaughtExceptionLogger.h"
+#import "MAURPostLocationTask.h"
 #import "INTULocationManager.h"
 
 // error messages
@@ -584,6 +585,18 @@ FMDBLogger *sqliteLogger;
 {
     DDLogDebug(@"%@ #dealloc", TAG);
     // currently noop
+}
+
+#pragma mark - Location transform
+
++ (void) setLocationTransform:(MAURLocationTransform _Nullable)transform
+{
+    [MAURPostLocationTask setLocationTransform:transform];
+}
+
++ (MAURLocationTransform _Nullable) locationTransform
+{
+    return [MAURPostLocationTask locationTransform];
 }
 
 @end

--- a/BackgroundGeolocation/MAURLocation.h
+++ b/BackgroundGeolocation/MAURLocation.h
@@ -11,6 +11,10 @@
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
 
+@class MAURLocation;
+
+typedef MAURLocation * _Nullable (^ MAURLocationTransform)(MAURLocation * _Nonnull location);
+
 typedef NS_ENUM(NSInteger, MAURLocationStatus) {
     MAURLocationDeleted = 0,
     MAURLocationPostPending = 1,

--- a/BackgroundGeolocation/MAURPostLocationTask.h
+++ b/BackgroundGeolocation/MAURPostLocationTask.h
@@ -14,12 +14,15 @@
 
 @interface MAURPostLocationTask : NSObject
 
-@property (nonatomic, weak) MAURConfig  *config;
+@property (nonatomic, weak) MAURConfig *config;
 
 - (void) add:(MAURLocation*)location;
 - (void) start;
 - (void) stop;
 - (void) sync;
+
++ (void) setLocationTransform:(MAURLocationTransform _Nullable)transform;
++ (MAURLocationTransform _Nullable) locationTransform;
 
 @end
 


### PR DESCRIPTION
## Motivation

A concern was raised by users, where they do not want coordinates to be transmitted from their home address.  
It's a common privacy issue.

Our idea was to let them set a "reverse fence" around their home. Where all coordinates transmitted within a certain radius - will be offset by around 1km.

## Implementation

In order to achieve the desired result, we have to intervene even when the app is in the background, or as a service. At this stage some user mode code like React Native's JS will not have been executed yet.

I came up with a "transform", where all coordinates pass through. You can modify them or return a new one. Or you can reject them by returning null.

Due to the fact that the Facade is in most cases not owned by the developer - for example in RN situation where it is owned by the RCT module, and that module is also owned by RN, we have to access the modules statically.
So static setters have been written for the Facade.

As I believe in separation of concerns, I left the issue of "how to filter", or in RN's situation "how to share settings with the transformer" to the user, to handle with a separate technique/library.

## Usage

In `didFinishLaunch` delegate method, write some code like this:

```
BackgroundGeolocationFacade.locationTransform = ^(MAURLocation * location) {
  location.latitude = @(location.latitude.doubleValue + 0.018);
  return location;
};
```

Note: The equivalent android PR is here: https://github.com/mauron85/background-geolocation-android/pull/8