### PR TITLE
Sent an event when the http request is unauthorized

### DIFF
--- a/BackgroundGeolocation/MAURBackgroundGeolocationFacade.m
+++ b/BackgroundGeolocation/MAURBackgroundGeolocationFacade.m
@@ -618,4 +618,12 @@ FMDBLogger *sqliteLogger;
     }
 }
 
+- (void) postLocationTaskHttpAuthorizationUpdates:(MAURPostLocationTask *)task
+{
+    if (_delegate && [_delegate respondsToSelector:@selector(onHttpAuthorization)])
+    {
+        [_delegate onHttpAuthorization];
+    }
+}
+
 @end

--- a/BackgroundGeolocation/MAURBackgroundSync.h
+++ b/BackgroundGeolocation/MAURBackgroundSync.h
@@ -16,6 +16,7 @@
 
 @optional
 - (void)backgroundSyncRequestedAbortUpdates:(MAURBackgroundSync * _Nonnull)task;
+- (void)backgroundSyncHttpAuthorizationUpdates:(MAURBackgroundSync * _Nonnull)task;
 
 @end
 

--- a/BackgroundGeolocation/MAURBackgroundSync.m
+++ b/BackgroundGeolocation/MAURBackgroundSync.m
@@ -154,6 +154,16 @@ NSString *stringFromFileSize(unsigned long long theSize)
             }
         });
     }
+
+    if (statusCode == 401)
+    {   
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (_delegate && [_delegate respondsToSelector:@selector(backgroundSyncHttpAuthorizationUpdates:)])
+            {
+                [_delegate backgroundSyncHttpAuthorizationUpdates:self];
+            }
+        });
+    }
 }
 
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data

--- a/BackgroundGeolocation/MAURPostLocationTask.h
+++ b/BackgroundGeolocation/MAURPostLocationTask.h
@@ -18,6 +18,7 @@
 
 @optional
 - (void)postLocationTaskRequestedAbortUpdates:(MAURPostLocationTask * _Nonnull)task;
+- (void)postLocationTaskHttpAuthorizationUpdates:(MAURPostLocationTask * _Nonnull)task;
 
 @end
 

--- a/BackgroundGeolocation/MAURPostLocationTask.m
+++ b/BackgroundGeolocation/MAURPostLocationTask.m
@@ -152,6 +152,16 @@ static MAURLocationTransform s_locationTransform = nil;
             }
         });
     }
+
+    if (statusCode == 401)
+    {   
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (_delegate && [_delegate respondsToSelector:@selector(postLocationTaskHttpAuthorizationUpdates:)])
+            {
+                [_delegate postLocationTaskHttpAuthorizationUpdates:self];
+            }
+        });
+    }
     
     // All 2xx statuses are okay
     if (statusCode >= 200 && statusCode < 300)
@@ -194,6 +204,14 @@ static MAURLocationTransform s_locationTransform = nil;
     if (_delegate && [_delegate respondsToSelector:@selector(postLocationTaskRequestedAbortUpdates:)])
     {
         [_delegate postLocationTaskRequestedAbortUpdates:self];
+    }
+}
+
+- (void)backgroundSyncHttpAuthorizationUpdates:(MAURBackgroundSync *)task
+{
+    if (_delegate && [_delegate respondsToSelector:@selector(postLocationTaskHttpAuthorizationUpdates:)])
+    {
+        [_delegate postLocationTaskHttpAuthorizationUpdates:self];
     }
 }
 

--- a/BackgroundGeolocation/MAURProviderDelegate.h
+++ b/BackgroundGeolocation/MAURProviderDelegate.h
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSInteger, MAUROperationalMode) {
 - (void) onLocationResume;
 - (void) onActivityChanged:(MAURActivity*)activity;
 - (void) onAbortRequested;
+- (void) onHttpAuthorization;
 - (void) onError:(NSError*)error;
 
 @end


### PR DESCRIPTION
related to [this](https://github.com/mauron85/react-native-background-geolocation/issues/307).

Library clients will be able to listen for 401 Unauthorized status codes received from http server.

Please note that I'm not iOS developer, and this is my first touch to objective-c