### PR TITLE
import global sqlite.h

### DIFF
--- a/BackgroundGeolocation/MAURSQLiteLocationDAO.m
+++ b/BackgroundGeolocation/MAURSQLiteLocationDAO.m
@@ -5,7 +5,7 @@
 //  Created by Marian Hello on 10/06/16.
 //
 
-#import "sqlite3.h"
+#import <sqlite3.h>
 #import <CoreLocation/CoreLocation.h>
 #import "MAURSQLiteHelper.h"
 #import "MAURGeolocationOpenHelper.h"


### PR DESCRIPTION
Builds fail with "sqlite.h not found" when other parts of the app make use of `sqlite.h`.
Using a global import fixes this.
